### PR TITLE
[FIX] Tests with pycoda-0.4

### DIFF
--- a/account_statement_coda_import/tests/test_coda_import.py
+++ b/account_statement_coda_import/tests/test_coda_import.py
@@ -160,9 +160,7 @@ class test_coda_import(common.TransactionCase):
             if st_line_obj['ref'] == '00170005':
                 # common infos
                 self.assertEqual(st_line_obj['name'],
-                                 'OVERBOEKING NAAR CENTRALE '
-                                 'REKENING\nOVERBOEKING NAAR '
-                                 'CENTRALE REKENING')
+                                 'OVERBOEKING NAAR CENTRALE REKENING')
                 self.assertEqual(st_line_obj['amount'], -15.0)
                 # additional info provided by CODA
                 # check that the bank information are correctly filled


### PR DESCRIPTION
In the latest version (0.4) of the coda parser (pycoda) comments from the details line are no more summurized in the globailsation
