### PR TITLE
Allow companyweb to be updated from external scripts

### DIFF
--- a/account_companyweb/model/res_partner.py
+++ b/account_companyweb/model/res_partner.py
@@ -37,6 +37,8 @@ class res_partner(orm.Model):
     _inherit = 'res.partner'
 
     def companyweb_information(self, cr, uid, ids, vat_number, context=None):
+        if not context:
+            context = {}
         login = self.pool['ir.config_parameter'].get_param(
             cr, uid, 'companyweb.login', False)
         pswd = self.pool['ir.config_parameter'].get_param(

--- a/account_companyweb/wizard/account_companyweb_wizard.py
+++ b/account_companyweb/wizard/account_companyweb_wizard.py
@@ -47,9 +47,10 @@ class account_companyweb_wizard(orm.TransientModel):
         'result': fields.float('Fiscal Year Profit/Loss (+/-)', readonly=True),
     }
 
-    def get_update_values(self, cr, uid, ids, wizard, context=None):
+    def get_update_values(self, cr, uid, ids, context=None):
         """ This method is designed to be inherited to add some field to
             update on res.partner"""
+        wizard = self.browse(cr, uid, ids)
         return {'name': wizard.name,
                 'is_company': True,
                 'street': wizard.street,
@@ -62,7 +63,7 @@ class account_companyweb_wizard(orm.TransientModel):
         res_partner_model = self.pool['res.partner']
         partner_id = context['active_id']
         this = self.browse(cr, uid, ids, context=context)[0]
-        update_values = self.get_update_values(cr, uid, ids, this,
+        update_values = self.get_update_values(cr, uid, ids,
                                                context=context)
         res_partner_model.write(cr, uid, [partner_id], update_values,
                                 context=context)


### PR DESCRIPTION
This PR allows updating of companyweb data from scripts, e.g. using the oerplib library to connect to an Odoo instance. The PR is written against 9.0, but applies cleanly against the 7.0 and 8.0 branches as well.

When calling Odoo methods over xmlrpc, one can't pass None nor Browse Records; this change rectifies the API so that this never happens.
