### PR TITLE
[9.0] Mis builder Report : Belgian VAT Declaration

### DIFF
--- a/l10n_be_mis_reports/README.rst
+++ b/l10n_be_mis_reports/README.rst
@@ -7,6 +7,8 @@ Belgium MIS reports
 
 This modules provides MIS Builder Report templates for the Belgium
 P&L and Balance Sheet according to the official models.
+It also provides a MIS Builder Report template for the Belgium VAT
+Declaration.
 
 Installation
 ============
@@ -27,9 +29,12 @@ templates provided by this module:
 
 * Belgium Profit & Loss
 * Belgium Balance Sheet
+* Belgium VAT Declaration
 
 To obtain correct results, the account codes prefixes must match the official
 Belgium chart of account.
+The tags on the belgian taxes must be set (account_tax_template.xml from odoo/addons/l10n_be).
+
 
 Usage
 =====

--- a/l10n_be_mis_reports/__openerp__.py
+++ b/l10n_be_mis_reports/__openerp__.py
@@ -39,6 +39,7 @@
         'data/mis_report_styles.xml',
         'data/mis_report_pl.xml',
         'data/mis_report_bs.xml',
+        'data/mis_report_vat.xml',
     ],
     'installable': True,
 }

--- a/l10n_be_mis_reports/__openerp__.py
+++ b/l10n_be_mis_reports/__openerp__.py
@@ -34,6 +34,7 @@
     'license': 'AGPL-3',
     'depends': [
         'mis_builder',  # OCA/account-financial-reporting
+        'l10n_be',
     ],
     'data': [
         'data/mis_report_styles.xml',

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -22,7 +22,7 @@
       <field name="name">cadre_2</field>
       <field name="description">Cadre II</field>
       <field name="expression"></field>
-      <field name="type">num</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">1</field>
@@ -31,7 +31,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_00</field>
       <field name="description">Grid 00</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', '=', 'Belgium VAT Form: grid 0')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=', ref('l10n_be.tax_tag_00').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -41,7 +41,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_01</field>
       <field name="description">Grid 01</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 01')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_01').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -51,7 +51,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_02</field>
       <field name="description">Grid 02</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 02')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_02').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -61,7 +61,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_03</field>
       <field name="description">Grid 03</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 03')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_03').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -71,7 +71,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_44</field>
       <field name="description">Grid 44</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 44')] </field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_44').id)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -81,7 +81,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_45</field>
       <field name="description">Grid 45</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 45')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_45').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -91,7 +91,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_46</field>
       <field name="description">Grid 46</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 46')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_46L').id)]+crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_46T').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -101,7 +101,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_47</field>
       <field name="description">Grid 47</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 47')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_47').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -111,7 +111,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_48</field>
       <field name="description">Grid 48</field>
-      <field name="expression">deb[][('tax_ids.tag_ids.name', 'like', '% 48')]</field>
+      <field name="expression">deb[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_48s44').id)]+deb[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_48s46T').id)]+deb[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_48s46L').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -121,7 +121,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_49</field>
       <field name="description">Grid 49</field>
-      <field name="expression">deb[][('tax_ids.tag_ids.name', 'like', '% 49')]</field>
+      <field name="expression">deb[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_49').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -132,7 +132,7 @@
       <field name="name">cadre_3</field>
       <field name="description">Cadre III</field>
       <field name="expression"></field>
-      <field name="type">num</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">101</field>
@@ -141,7 +141,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_81</field>
       <field name="description">Grid 81</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 81')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_81').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -151,7 +151,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_82</field>
       <field name="description">Grid 82</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 82')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_82').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -161,7 +161,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_83</field>
       <field name="description">Grid 83</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 83')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_83').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -171,7 +171,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_84</field>
       <field name="description">Grid 84</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 84')] </field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_84').id)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -181,7 +181,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_85</field>
       <field name="description">Grid 85</field>
-      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 85')]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_85').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -191,7 +191,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_86</field>
       <field name="description">Grid 86</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 86')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_86').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -201,7 +201,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_87</field>
       <field name="description">Grid 87</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 87')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_87').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -211,7 +211,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_88</field>
       <field name="description">Grid 88</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 88')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.id', '=',ref('l10n_be.tax_tag_88').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -222,7 +222,7 @@
       <field name="name">cadre_4</field>
       <field name="description">Cadre IV</field>
       <field name="expression"></field>
-      <field name="type">num</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">181</field>
@@ -231,7 +231,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_54</field>
       <field name="description">Grid 54</field>
-      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 54')] </field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_54').id)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -241,7 +241,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_55</field>
       <field name="description">Grid 55</field>
-      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 55')]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_55').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -251,7 +251,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_56</field>
       <field name="description">Grid 56</field>
-      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 56')]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_56').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -261,7 +261,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_57</field>
       <field name="description">Grid 57</field>
-      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 57')]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_57').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -271,7 +271,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_61</field>
       <field name="description">Grid 61</field>
-      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 61')] </field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_61').id)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -281,7 +281,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_63</field>
       <field name="description">Grid 63</field>
-      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 63')] </field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_63').id)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -302,7 +302,7 @@
       <field name="name">cadre_5</field>
       <field name="description">Cadre V</field>
       <field name="expression"></field>
-      <field name="type">num</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">261</field>
@@ -311,7 +311,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_59</field>
       <field name="description">Grid 59</field>
-      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 59')]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_59').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -321,7 +321,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_62</field>
       <field name="description">Grid 62</field>
-      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 62')]</field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_62').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -331,7 +331,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_64</field>
       <field name="description">Grid 64</field>
-      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 64')]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.id', '=',ref('l10n_be.tax_tag_64').id)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -352,7 +352,7 @@
       <field name="name">cadre_6</field>
       <field name="description">Cadre VI</field>
       <field name="expression"></field>
-      <field name="type">num</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">301</field>
@@ -383,7 +383,7 @@
       <field name="name">control</field>
       <field name="description">Control</field>
       <field name="expression"></field>
-      <field name="type">num</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">900</field>
@@ -392,8 +392,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_85</field>
       <field name="description">Control Grid 85: [85] x 0.21 >= [63]</field>
-      <field name="expression">min(grid_85*0.21-grid_63,AccountingNone)</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if (grid_85)*0.21 >= (grid_63) else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">901</field>
@@ -402,8 +402,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_49</field>
       <field name="description">Control Grid 49: [49] x 0.21 >= [64]</field>
-      <field name="expression">min(grid_49*0.21-grid_64,AccountingNone)</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if (grid_49)*0.21 >= (grid_64) else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">902</field>
@@ -411,9 +411,9 @@
      <record model="mis.report.kpi" id="mis_report_vat_control_54">
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_54</field>
-      <field name="description">Control Grid 54: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 - [54]</field>
-      <field name="expression">(+grid_01*0.06+grid_02*0.12+grid_03*0.21)-grid_54</field>
-      <field name="type">num</field>
+      <field name="description">Control Grid 54: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 >= [54]</field>
+      <field name="expression">'V' if ((grid_01*0.21)+(grid_02*0.12)+(grid_03*0.21)) >= (grid_54) else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">903</field>
@@ -422,8 +422,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_55</field>
       <field name="description">Control Grid 55: [84] + [86] + [88] x 0.21 >= [55]</field>
-      <field name="expression">min((grid_84 + grid_86 + grid_88)*0.21-grid_55,AccountingNone)</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if (grid_84 + grid_86 + grid_88)*0.21 >= (grid_55) else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">904</field>
@@ -432,8 +432,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_87</field>
       <field name="description">Control Grid 87: [85] + [87] x 0.21 >= [56] + [57]</field>
-      <field name="expression">min((grid_85 + grid_87)*0.21-grid_57-grid_56,AccountingNone)</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if (grid_85) + (grid_87*0.21) >= (grid_56 + grid_57) else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">905</field>
@@ -442,8 +442,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_59</field>
       <field name="description">Control Grid 59: [81] + [82] + [83] + [84] + [85] x 0.5 >= [59]</field>
-      <field name="expression">min((grid_81 + grid_82 + grid_83 + grid_84 + grid_85)*0.5-grid_59,AccountingNone)</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if (grid_81 + grid_82 + grid_83 + grid_84 + grid_85)*0.5 >= grid_59 else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">906</field>
@@ -452,8 +452,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_70</field>
       <field name="description">Control 70 vs Cadre II</field>
-      <field name="expression">abs(grid_00 + grid_01 + grid_02 + grid_03 + balp[70%])</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if abs(grid_00 + grid_01 + grid_02 + grid_03 + balp[70%]) >= 0 else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">907</field>
@@ -462,8 +462,8 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_60</field>
       <field name="description">Control 60 vs [81]</field>
-      <field name="expression">abs(grid_81 - balp[60%])</field>
-      <field name="type">num</field>
+      <field name="expression">'V' if abs(grid_81 - balp[60%])>= 0 else 'X'</field>
+      <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">908</field>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
   <data>
+    <!-- wizard and menu -->
+    <record id="action_mis_report_vat" model="ir.actions.server">
+      <field name="name">VAT Declaration</field>
+      <field name="model_id" ref="account.model_account_chart_template"/>
+      <field name="state">code</field>
+      <field name="code">action = model.env.ref('l10n_be_mis_reports.mis_report_vat').get_wizard_report_action()</field>
+      <field name="type">ir.actions.server</field>
+      <field name="condition">True</field>
+    </record>
+    <menuitem action="action_mis_report_vat" id="menu_mis_report_vat" parent="l10n_be.account_reports_be_statements_menu"/>
+
+    <!-- mis.report -->
     <record model="mis.report" id="mis_report_vat">
       <field name="name">Belgium Value Added Tax Report Sheet</field>
       <field name="style_id" ref="mis_report_style_l10n_be_base"/>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -3,6 +3,7 @@
   <data>
     <record model="mis.report" id="mis_report_vat">
       <field name="name">Belgium Value Added Taxes Report Sheet (Full Model)</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_base"/>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_cadre_2">
       <field name="report_id" ref="mis_report_vat"/>
@@ -18,7 +19,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_00</field>
       <field name="description">Grid 00</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', '=', 'Belgium VAT Form: grid 0'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'Belgium VAT Form: grid 0'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -28,7 +29,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_01</field>
       <field name="description">Grid 01</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 01'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 01'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -38,7 +39,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_02</field>
       <field name="description">Grid 02</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 02'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 02'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -48,7 +49,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_03</field>
       <field name="description">Grid 03</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 03'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 03'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -58,7 +59,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_44</field>
       <field name="description">Grid 44</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 44'),('credit','>',0)] </field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 44'),('credit','>',0)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -68,7 +69,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_45</field>
       <field name="description">Grid 45</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 45'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 45'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -78,7 +79,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_46</field>
       <field name="description">Grid 46</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 46'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 46'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -88,7 +89,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_47</field>
       <field name="description">Grid 47</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 47'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 47'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -98,7 +99,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_48</field>
       <field name="description">Grid 48</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 48'),('debit','>',0)] </field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 48'),('debit','>',0)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -108,7 +109,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_49</field>
       <field name="description">Grid 49</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 49'),('debit','>',0)]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 49'),('debit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -128,7 +129,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_81</field>
       <field name="description">Grid 81</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 81')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 81')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -138,7 +139,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_82</field>
       <field name="description">Grid 82</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 82')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 82')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -148,7 +149,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_83</field>
       <field name="description">Grid 83</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 83')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 83')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -158,7 +159,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_84</field>
       <field name="description">Grid 84</field>
-      <field name="expression"> -bal[%][('tax_ids.tag_ids.name', 'like', '% 84'),('credit','>',0)] </field>
+      <field name="expression"> -bal[][('tax_ids.tag_ids.name', 'like', '% 84'),('credit','>',0)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -168,7 +169,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_85</field>
       <field name="description">Grid 85</field>
-      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 85'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 85'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -178,7 +179,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_86</field>
       <field name="description">Grid 86</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 86')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 86')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -188,7 +189,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_87</field>
       <field name="description">Grid 87</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 87')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 87')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -198,7 +199,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_88</field>
       <field name="description">Grid 88</field>
-      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 88')]</field>
+      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 88')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -218,7 +219,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_54</field>
       <field name="description">Grid 54</field>
-      <field name="expression">-bal[%][('tax_line_id.tag_ids.name', 'like', '% 54'),('credit','>',0)] </field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', 'like', '% 54'),('credit','>',0)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -238,7 +239,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_55</field>
       <field name="description">Grid 55</field>
-      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 55'),('debit','>',0)]</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 55'),('debit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -248,7 +249,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_56</field>
       <field name="description">Grid 56</field>
-      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 56'),('debit','>',0)]</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 56'),('debit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -258,7 +259,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_57</field>
       <field name="description">Grid 57</field>
-      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 57'),('debit','>',0)]</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 57'),('debit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -268,7 +269,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_61</field>
       <field name="description">Grid 61</field>
-      <field name="expression"> -bal[%][('tax_line_id.tag_ids.name', 'like', '% 61'),('credit','>',0)] </field>
+      <field name="expression"> -bal[][('tax_line_id.tag_ids.name', 'like', '% 61'),('credit','>',0)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -278,7 +279,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_63</field>
       <field name="description">Grid 63</field>
-      <field name="expression">-bal[%][('tax_line_id.tag_ids.name', 'like', '% 63'),('credit','>',0)] </field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', 'like', '% 63'),('credit','>',0)] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -308,7 +309,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_59</field>
       <field name="description">Grid 59</field>
-      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 59'),('debit','>',0)]</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 59'),('debit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -318,7 +319,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_62</field>
       <field name="description">Grid 62</field>
-      <field name="expression">-bal[%][('tax_line_id.tag_ids.name', 'like', '% 62'),('credit','>',0)]</field>
+      <field name="expression">-bal[][('tax_line_id.tag_ids.name', 'like', '% 62'),('credit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -328,7 +329,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_64</field>
       <field name="description">Grid 64</field>
-      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 64'),('debit','>',0)]</field>
+      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 64'),('debit','>',0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -2,7 +2,7 @@
 <openerp>
   <data>
     <record model="mis.report" id="mis_report_vat">
-      <field name="name">Belgium Value Added Taxes Report Sheet (Full Model)</field>
+      <field name="name">Belgium Value Added Tax Report Sheet</field>
       <field name="style_id" ref="mis_report_style_l10n_be_base"/>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_cadre_2">
@@ -224,16 +224,6 @@
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">190</field>
-    </record>
-    <record model="mis.report.kpi" id="mis_report_vat_check1">
-      <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">check1</field>
-      <field name="description">VAT calculated -should be equal to grid 54</field>
-      <field name="expression">grid_01 * 0.06 + grid_02 * 0.12 + grid_03 * 0.21</field>
-      <field name="type">num</field>
-      <field name="compare_method">pct</field>
-      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
-      <field name="sequence">200</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_55">
       <field name="report_id" ref="mis_report_vat"/>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -359,7 +359,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_71</field>
       <field name="description">Grid 71 : Taxes due to the State</field>
-      <field name="expression">grid_xx - grid_yy</field>
+      <field name="expression">abs(max(grid_xx - grid_yy, AccountingNone))</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_1"/>
@@ -369,7 +369,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_72</field>
       <field name="description">Grid 72 : Taxes due by the State</field>
-      <field name="expression">grid_yy - grid_xx</field>
+      <field name="expression">abs(max(grid_yy - grid_xx, AccountingNone))</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_1"/>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <record model="mis.report" id="mis_report_vat">
+      <field name="name">Belgium Value Added Taxes Report Sheet (Full Model)</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_cadre_2">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">cadre_2</field>
+      <field name="description">Cadre II</field>
+      <field name="expression"></field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="sequence">1</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_00">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_00</field>
+      <field name="description">Grid 00</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', '=', 'Belgium VAT Form: grid 0'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">10</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_01">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_01</field>
+      <field name="description">Grid 01</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 01'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">20</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_02">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_02</field>
+      <field name="description">Grid 02</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 02'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">30</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_03">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_03</field>
+      <field name="description">Grid 03</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 03'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">40</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_44">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_44</field>
+      <field name="description">Grid 44</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 44'),('credit','>',0)] </field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">50</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_45">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_45</field>
+      <field name="description">Grid 45</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 45'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">60</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_46">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_46</field>
+      <field name="description">Grid 46</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 46'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">70</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_47">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_47</field>
+      <field name="description">Grid 47</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 47'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">80</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_48">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_48</field>
+      <field name="description">Grid 48</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 48'),('debit','>',0)] </field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">90</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_49">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_49</field>
+      <field name="description">Grid 49</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 49'),('debit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">100</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_cadre_3">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">cadre_3</field>
+      <field name="description">Cadre III</field>
+      <field name="expression"></field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="sequence">101</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_81">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_81</field>
+      <field name="description">Grid 81</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 81')]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">110</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_82">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_82</field>
+      <field name="description">Grid 82</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 82')]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">120</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_83">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_83</field>
+      <field name="description">Grid 83</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 83')]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">130</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_84">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_84</field>
+      <field name="description">Grid 84</field>
+      <field name="expression"> -bal[%][('tax_ids.tag_ids.name', 'like', '% 84'),('credit','>',0)] </field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">140</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_85">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_85</field>
+      <field name="description">Grid 85</field>
+      <field name="expression">-bal[%][('tax_ids.tag_ids.name', 'like', '% 85'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">150</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_86">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_86</field>
+      <field name="description">Grid 86</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 86')]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">160</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_87">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_87</field>
+      <field name="description">Grid 87</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 87')]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">170</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_88">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_88</field>
+      <field name="description">Grid 88</field>
+      <field name="expression">bal[%][('tax_ids.tag_ids.name', 'like', '% 88')]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">180</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_cadre_4">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">cadre_4</field>
+      <field name="description">Cadre IV</field>
+      <field name="expression"></field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="sequence">181</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_54">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_54</field>
+      <field name="description">Grid 54</field>
+      <field name="expression">-bal[%][('tax_line_id.tag_ids.name', 'like', '% 54'),('credit','>',0)] </field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">190</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_check1">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">check1</field>
+      <field name="description">VAT calculated -should be equal to grid 54</field>
+      <field name="expression">grid_01 * 0.06 + grid_02 * 0.12 + grid_03 * 0.21</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">200</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_55">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_55</field>
+      <field name="description">Grid 55</field>
+      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 55'),('debit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">210</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_56">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_56</field>
+      <field name="description">Grid 56</field>
+      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 56'),('debit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">220</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_57">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_57</field>
+      <field name="description">Grid 57</field>
+      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 57'),('debit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">230</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_61">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_61</field>
+      <field name="description">Grid 61</field>
+      <field name="expression"> -bal[%][('tax_line_id.tag_ids.name', 'like', '% 61'),('credit','>',0)] </field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">240</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_63">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_63</field>
+      <field name="description">Grid 63</field>
+      <field name="expression">-bal[%][('tax_line_id.tag_ids.name', 'like', '% 63'),('credit','>',0)] </field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">250</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_xx">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_xx</field>
+      <field name="description">Grid xx (sum of 54, 55, 56, 57, 61, 63)</field>
+      <field name="expression">+grid_54+grid_55+grid_56+grid_57+grid_61+grid_63</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_4"/>
+      <field name="sequence">260</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_cadre_5">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">cadre_5</field>
+      <field name="description">Cadre V</field>
+      <field name="expression"></field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="sequence">261</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_59">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_59</field>
+      <field name="description">Grid 59</field>
+      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 59'),('debit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">270</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_62">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_62</field>
+      <field name="description">Grid 62</field>
+      <field name="expression">-bal[%][('tax_line_id.tag_ids.name', 'like', '% 62'),('credit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">280</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_64">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_64</field>
+      <field name="description">Grid 64</field>
+      <field name="expression">bal[%][('tax_line_id.tag_ids.name', 'like', '% 64'),('debit','>',0)]</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">290</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_yy">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_yy</field>
+      <field name="description">Grid yy (sum of grid 59, 62, 64)</field>
+      <field name="expression">grid_59+grid_62+grid_64</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_4"/>
+      <field name="sequence">300</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_cadre_6">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">cadre_6</field>
+      <field name="description">Cadre VI</field>
+      <field name="expression"></field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="sequence">301</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_71">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_71</field>
+      <field name="description">Grid 71 : Taxes due to the State</field>
+      <field name="expression">grid_xx - grid_yy</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_1"/>
+      <field name="sequence">310</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_grid_72">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">grid_72</field>
+      <field name="description">Grid 72 : Taxes due by the State</field>
+      <field name="expression">grid_yy - grid_xx</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_1"/>
+      <field name="sequence">320</field>
+    </record>
+  </data>
+</openerp>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -421,7 +421,7 @@
      <record model="mis.report.kpi" id="mis_report_vat_control_55">
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_55</field>
-      <field name="description">Control Grid 55: [84] + [86] + [88] x 0.21 >= [55]</field>
+      <field name="description">Control Grid 55: ([84] + [86] + [88]) x 0.21 >= [55]</field>
       <field name="expression">'V' if (grid_84 + grid_86 + grid_88)*0.21 >= (grid_55) else 'X'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
@@ -431,8 +431,8 @@
      <record model="mis.report.kpi" id="mis_report_vat_control_87">
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_87</field>
-      <field name="description">Control Grid 87: [85] + [87] x 0.21 >= [56] + [57]</field>
-      <field name="expression">'V' if (grid_85) + (grid_87*0.21) >= (grid_56 + grid_57) else 'X'</field>
+      <field name="description">Control Grid 87: ([85] + [87]) x 0.21 >= [56] + [57]</field>
+      <field name="expression">'V' if (grid_85 + grid_87)*0.21 >= (grid_56 + grid_57) else 'X'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -441,7 +441,7 @@
      <record model="mis.report.kpi" id="mis_report_vat_control_59">
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">ctrl_59</field>
-      <field name="description">Control Grid 59: [81] + [82] + [83] + [84] + [85] x 0.5 >= [59]</field>
+      <field name="description">Control Grid 59: ([81] + [82] + [83] + [84] + [85]) x 0.5 >= [59]</field>
       <field name="expression">'V' if (grid_81 + grid_82 + grid_83 + grid_84 + grid_85)*0.5 >= grid_59 else 'X'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -19,7 +19,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_00</field>
       <field name="description">Grid 00</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', '=', 'Belgium VAT Form: grid 0'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', '=', 'Belgium VAT Form: grid 0')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -29,7 +29,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_01</field>
       <field name="description">Grid 01</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 01'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 01')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -39,7 +39,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_02</field>
       <field name="description">Grid 02</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 02'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 02')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -49,7 +49,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_03</field>
       <field name="description">Grid 03</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 03'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 03')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -59,7 +59,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_44</field>
       <field name="description">Grid 44</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 44'),('credit','>',0)] </field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 44')] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -69,7 +69,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_45</field>
       <field name="description">Grid 45</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 45'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 45')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -79,7 +79,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_46</field>
       <field name="description">Grid 46</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 46'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 46')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -89,7 +89,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_47</field>
       <field name="description">Grid 47</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 47'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 47')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -99,7 +99,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_48</field>
       <field name="description">Grid 48</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 48'),('debit','>',0)] </field>
+      <field name="expression">deb[][('tax_ids.tag_ids.name', 'like', '% 48')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -109,7 +109,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_49</field>
       <field name="description">Grid 49</field>
-      <field name="expression">bal[][('tax_ids.tag_ids.name', 'like', '% 49'),('debit','>',0)]</field>
+      <field name="expression">deb[][('tax_ids.tag_ids.name', 'like', '% 49')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -159,7 +159,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_84</field>
       <field name="description">Grid 84</field>
-      <field name="expression"> -bal[][('tax_ids.tag_ids.name', 'like', '% 84'),('credit','>',0)] </field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 84')] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -169,7 +169,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_85</field>
       <field name="description">Grid 85</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.name', 'like', '% 85'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_ids.tag_ids.name', 'like', '% 85')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -219,7 +219,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_54</field>
       <field name="description">Grid 54</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', 'like', '% 54'),('credit','>',0)] </field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 54')] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -229,7 +229,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_55</field>
       <field name="description">Grid 55</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 55'),('debit','>',0)]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 55')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -239,7 +239,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_56</field>
       <field name="description">Grid 56</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 56'),('debit','>',0)]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 56')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -249,7 +249,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_57</field>
       <field name="description">Grid 57</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 57'),('debit','>',0)]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 57')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -259,7 +259,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_61</field>
       <field name="description">Grid 61</field>
-      <field name="expression"> -bal[][('tax_line_id.tag_ids.name', 'like', '% 61'),('credit','>',0)] </field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 61')] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -269,7 +269,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_63</field>
       <field name="description">Grid 63</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', 'like', '% 63'),('credit','>',0)] </field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 63')] </field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -299,7 +299,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_59</field>
       <field name="description">Grid 59</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 59'),('debit','>',0)]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 59')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -309,7 +309,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_62</field>
       <field name="description">Grid 62</field>
-      <field name="expression">-bal[][('tax_line_id.tag_ids.name', 'like', '% 62'),('credit','>',0)]</field>
+      <field name="expression">crd[][('tax_line_id.tag_ids.name', 'like', '% 62')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -319,7 +319,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_64</field>
       <field name="description">Grid 64</field>
-      <field name="expression">bal[][('tax_line_id.tag_ids.name', 'like', '% 64'),('debit','>',0)]</field>
+      <field name="expression">deb[][('tax_line_id.tag_ids.name', 'like', '% 64')]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -377,5 +377,96 @@
       <field name="style_id" ref="mis_report_style_l10n_be_1"/>
       <field name="sequence">320</field>
     </record>
+          <!-- controls -->
+      <record model="mis.report.kpi" id="mis_report_vat_control">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">control</field>
+      <field name="description">Control</field>
+      <field name="expression"></field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="sequence">900</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_control_85">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_85</field>
+      <field name="description">Control Grid 85: [85] x 0.21 >= [63]</field>
+      <field name="expression">min(grid_85*0.21-grid_63,AccountingNone)</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">901</field>
+    </record>
+    <record model="mis.report.kpi" id="mis_report_vat_control_49">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_49</field>
+      <field name="description">Control Grid 49: [49] x 0.21 >= [64]</field>
+      <field name="expression">min(grid_49*0.21-grid_64,AccountingNone)</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">902</field>
+    </record>
+     <record model="mis.report.kpi" id="mis_report_vat_control_54">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_54</field>
+      <field name="description">Control Grid 54: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 - [54]</field>
+      <field name="expression">(+grid_01*0.06+grid_02*0.12+grid_03*0.21)-grid_54</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">903</field>
+    </record>
+     <record model="mis.report.kpi" id="mis_report_vat_control_55">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_55</field>
+      <field name="description">Control Grid 55: [84] + [86] + [88] x 0.21 >= [55]</field>
+      <field name="expression">min((grid_84 + grid_86 + grid_88)*0.21-grid_55,AccountingNone)</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">904</field>
+    </record>
+     <record model="mis.report.kpi" id="mis_report_vat_control_87">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_87</field>
+      <field name="description">Control Grid 87: [85] + [87] x 0.21 >= [56] + [57]</field>
+      <field name="expression">min((grid_85 + grid_87)*0.21-grid_57-grid_56,AccountingNone)</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">905</field>
+    </record>
+     <record model="mis.report.kpi" id="mis_report_vat_control_59">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_59</field>
+      <field name="description">Control Grid 59: [81] + [82] + [83] + [84] + [85] x 0.5 >= [59]</field>
+      <field name="expression">min((grid_81 + grid_82 + grid_83 + grid_84 + grid_85)*0.5-grid_59,AccountingNone)</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">906</field>
+    </record>
+     <record model="mis.report.kpi" id="mis_report_vat_control_70">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_70</field>
+      <field name="description">Control 70 vs Cadre II</field>
+      <field name="expression">abs(grid_00 + grid_01 + grid_02 + grid_03 + balp[70%])</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">907</field>
+    </record>
+     <record model="mis.report.kpi" id="mis_report_vat_control_60">
+      <field name="report_id" ref="mis_report_vat"/>
+      <field name="name">ctrl_60</field>
+      <field name="description">Control 60 vs [81]</field>
+      <field name="expression">abs(grid_81 - balp[60%])</field>
+      <field name="type">num</field>
+      <field name="compare_method">pct</field>
+      <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="sequence">908</field>
+    </record>
   </data>
 </openerp>

--- a/l10n_be_mis_reports/i18n/fr.po
+++ b/l10n_be_mis_reports/i18n/fr.po
@@ -962,17 +962,17 @@ msgstr "Contrôle Grille 54 : [01] x 0.06 + [02] x 0.12 + [03] x 0.21 - [54]"
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_55
 msgid "ctrl_55"
-msgstr "Contrôle Grille 55 : [84] + [86] + [88] x 0.21 >= [55]"
+msgstr "Contrôle Grille 55 : ([84] + [86] + [88]) x 0.21 >= [55]"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_87
 msgid "ctrl_87"
-msgstr "Contrôle Grille 87 : [85] + [87] x 0.21 >= [56] + [57]"
+msgstr "Contrôle Grille 87 : ([85] + [87]) x 0.21 >= [56] + [57]"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_59
 msgid "ctrl_59"
-msgstr "Contrôle Grille 59 : [81] + [82] + [83] + [84] + [85] x 0.5 >= [59]"
+msgstr "Contrôle Grille 59 : ([81] + [82] + [83] + [84] + [85]) x 0.5 >= [59]"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_70

--- a/l10n_be_mis_reports/i18n/fr.po
+++ b/l10n_be_mis_reports/i18n/fr.po
@@ -938,3 +938,48 @@ msgstr "[71] Taxe due à l'Etat: grille XX - grille YY"
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_72
 msgid "Grid 72"
 msgstr "[72] Sommes dues par l'Etat: grille YY - grille XX"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control
+msgid "control"
+msgstr "Contrôles"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_85
+msgid "ctrl_85"
+msgstr "Contrôle Grille 85 : [85] x 0.21 >= [63]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_49
+msgid "ctrl_49"
+msgstr "Contrôle Grille 49 : [49] x 0.21 >= [64]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_54
+msgid "ctrl_54"
+msgstr "Contrôle Grille 54 : [01] x 0.06 + [02] x 0.12 + [03] x 0.21 - [54]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_55
+msgid "ctrl_55"
+msgstr "Contrôle Grille 55 : [84] + [86] + [88] x 0.21 >= [55]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_87
+msgid "ctrl_87"
+msgstr "Contrôle Grille 87 : [85] + [87] x 0.21 >= [56] + [57]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_59
+msgid "ctrl_59"
+msgstr "Contrôle Grille 59 : [81] + [82] + [83] + [84] + [85] x 0.5 >= [59]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_70
+msgid "ctrl_70"
+msgstr "Contrôle Grille 70 vs Cadre II"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_60
+msgid "ctrl_60"
+msgstr "Contrôle Grille 60 vs [81]"

--- a/l10n_be_mis_reports/i18n/fr.po
+++ b/l10n_be_mis_reports/i18n/fr.po
@@ -753,3 +753,188 @@ msgstr "Réserves immunisées [132]"
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_bs_fr133
 msgid "Work in Progress [32]"
 msgstr "En-cours de fabrication [32]"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report,name:l10n_be_mis_reports.mis_report_vat
+msgid "Belgium Value Added Tax Report Sheet"
+msgstr "Déclaration TVA belge"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_cadre_2
+msgid "Cadre II"
+msgstr "Cadre II"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_00
+msgid "Grid 00"
+msgstr "[00] A. Opérations soumises à un régime particulier"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_01
+msgid "Grid 01"
+msgstr "[01] B. Opérations pour lesquelles la TVA est due au taux de 6 p.c."
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_02
+msgid "Grid 01"
+msgstr "[02] B. Opérations pour lesquelles la TVA est due au taux de 12 p.c."
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_03
+msgid "Grid 03"
+msgstr "[03] B. Opérations pour lesquelles la TVA est due au taux de 21 p.c."
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_44
+msgid "Grid 44"
+msgstr "[44] C. Services pour lesquels la TVA étrangère est due par le cocontractant"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_45
+msgid "Grid 45"
+msgstr "[45] D. Opérations pour lesquelles la TVA est due par le cocontractant"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_46
+msgid "Grid 46"
+msgstr " [46] E. Livraisons intracommunautaires exemptées effectuées en Belgique et ventes ABC"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_47
+msgid "Grid 47"
+msgstr "[47] F. Autres opérations exemptées et autres opérations effectuées à l'étranger"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_48
+msgid "Grid 48"
+msgstr "[48] G. Montant des NC délivrées et des corrections négatives relatif aux opérations inscrites en grilles 44 et46"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_49
+msgid "Grid 49"
+msgstr "[49] G. Montant des NC délivrées et des corrections négatives relatif aux autres opérations du cadre II"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_cadre_3
+msgid "Cadre III"
+msgstr "Cadre III"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_81
+msgid "Grid 81"
+msgstr "[81] A. Montant des opérations à l'entrée compte tenu des notes de crédit reçues et autres corrections : marchandises, matières premières et matières auxiliaires"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_82
+msgid "Grid 82"
+msgstr "[82] A. Montant des opérations à l'entrée compte tenu des notes de crédit reçues et autres corrections : services et biens divers"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_83
+msgid "Grid 83"
+msgstr "[83] A. Montant des opérations à l'entrée compte tenu des notes de crédit reçues et autres corrections : biens d'investissement"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_84
+msgid "Grid 84"
+msgstr "[84] B. Montant des notes de crédits reçues et des corrections négatives relatif aux opérations inscrites en grilles 86 et 88"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_85
+msgid "Grid 85"
+msgstr "[85] B. Montant des notes de crédits reçues et des corrections négatives relatif aux autres opérations du cadre III"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_86
+msgid "Grid 86"
+msgstr "[86] C. Acquisitions intracommunautaires effectuées en Belgique et ventes ABC"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_87
+msgid "Grid 87"
+msgstr "[87] D. Autres opérations à l'entrée pour lesquelles la TVA est due par le déclarant"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_88
+msgid "Grid 88"
+msgstr "[88] E. Services intracommunautaires avec report de perception"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_cadre_4
+msgid "Cadre IV"
+msgstr "Cadre IV"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_54
+msgid "Grid 54"
+msgstr "[54] A. TVA relative aux opérations déclarées en grilles 01, 02 et 03"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_55
+msgid "Grid 55"
+msgstr "[55] A. TVA relative aux opérations déclarées en grilles 86 et 88"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_56
+msgid "Grid 56"
+msgstr "[56] A. TVA relative aux opérations déclarées en grille 87, à l'exception des importations avec report de perception"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_57
+msgid "Grid 57"
+msgstr "[57] B. TVA relative aux importations avec report de perception"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_61
+msgid "Grid 61"
+msgstr "[61] C. Diverses régularisations TVA en faveur de l'Etat"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_63
+msgid "Grid 63"
+msgstr "[63] D. TVA à reverser mentionnée sur les notes de crédit reçues"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_xx
+msgid "Grid xx (sum of 54, 55, 56, 57, 61, 63)"
+msgstr "[xx] Total des grilles 54, 55, 57, 61 et 63"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_cadre_5
+msgid "Cadre V"
+msgstr "Cadre V"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_59
+msgid "Grid 59"
+msgstr "[59] A. TVA déductible"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_62
+msgid "Grid 62"
+msgstr "[62] B. Diverses régularisations TVA en faveur du déclarant"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_64
+msgid "Grid 64"
+msgstr "[64] C. TVA à récupérer mentionnée sur les notes de crédit délivrées"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_yy
+msgid "Grid yy (sum of grid 59, 62, 64)"
+msgstr "[yy] Total des grilles 59, 62 et 64"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_cadre_6
+msgid "Cadre VI"
+msgstr "Cadre VI"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_71
+msgid "Grid 71"
+msgstr "[71] Taxe due à l'Etat: grille XX - grille YY"
+
+#. module: l10n_be_mis_reports
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_grid_72
+msgid "Grid 72"
+msgstr "[72] Sommes dues par l'Etat: grille YY - grille XX"

--- a/l10n_be_mis_reports/i18n/fr.po
+++ b/l10n_be_mis_reports/i18n/fr.po
@@ -977,9 +977,9 @@ msgstr "Contrôle Grille 59 : [81] + [82] + [83] + [84] + [85] x 0.5 >= [59]"
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_70
 msgid "ctrl_70"
-msgstr "Contrôle Grille 70 vs Cadre II"
+msgstr "Contrôle Compte 70 vs Cadre II"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_60
 msgid "ctrl_60"
-msgstr "Contrôle Grille 60 vs [81]"
+msgstr "Contrôle Compte 60 vs [81]"


### PR DESCRIPTION
This PR adds a new template in the MIS Builder Templates for Belgium : the VAT Declaration. It is based on the tags on the taxes. The translation has been made in French only.
Improvement to come : add the series of logical and arithmetical checks that are usually provided by accounting tools.

It has been validated with an accounting expert for the more usual grids (01, 03, 49, 81, 82, 85, 54, 63, 59, 64, 71/72).

@sbidoul here is my contribution for the VAT report