### PR TITLE
[9.0][IMP] l10n_be_mis_reports: auto expand account details

### DIFF
--- a/l10n_be_mis_reports/data/mis_report_pl.xml
+++ b/l10n_be_mis_reports/data/mis_report_pl.xml
@@ -25,6 +25,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">20</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr206">
@@ -35,6 +37,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">30</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr207">
@@ -45,6 +49,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">40</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr208">
@@ -55,6 +61,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">50</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr209">
@@ -85,6 +93,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_4"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">80</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr212">
@@ -95,6 +105,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_4"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">90</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr213">
@@ -105,6 +117,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">100</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr214">
@@ -115,6 +129,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">110</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr215">
@@ -125,6 +141,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">120</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr216">
@@ -135,6 +153,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">130</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr217">
@@ -145,6 +165,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">140</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr218">
@@ -155,6 +177,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">150</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr219">
@@ -165,6 +189,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">160</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr203">
@@ -195,6 +221,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">190</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr222">
@@ -205,6 +233,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">200</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr223">
@@ -215,6 +245,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">210</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr224">
@@ -225,6 +257,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">220</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr225">
@@ -235,6 +269,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">230</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr226">
@@ -245,6 +281,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">240</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr227">
@@ -255,6 +293,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">250</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr202">
@@ -285,6 +325,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">280</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr230">
@@ -295,6 +337,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">290</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr231">
@@ -305,6 +349,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">300</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr232">
@@ -315,6 +361,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">310</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr233">
@@ -325,6 +373,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">320</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr234">
@@ -345,6 +395,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">340</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr236">
@@ -355,6 +407,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">350</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr237">
@@ -365,6 +419,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">360</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr238">
@@ -375,6 +431,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">370</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr239">
@@ -385,6 +443,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">380</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr240">
@@ -395,6 +455,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">390</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr201">
@@ -415,6 +477,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">410</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr242">
@@ -425,6 +489,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">420</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr243">
@@ -445,6 +511,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_4"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">440</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr245">
@@ -455,6 +523,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_4"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">450</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr200">
@@ -475,6 +545,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">470</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr247">
@@ -485,6 +557,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">480</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_pl_fr199">

--- a/l10n_be_mis_reports/data/mis_report_styles.xml
+++ b/l10n_be_mis_reports/data/mis_report_styles.xml
@@ -50,5 +50,15 @@
       <field name="indent_level">3</field>
     </record>
 
+    <record id="mis_report_style_l10n_be_acc_det" model="mis.report.style">
+      <field name="name">l10n_be account detail</field>
+      <field name="indent_level_inherit" eval="0"/>
+      <field name="indent_level">4</field>
+      <field name="font_style_inherit" eval="0"/>
+      <field name="font_style">italic</field>
+      <field name="font_size_inherit" eval="0"/>
+      <field name="font_size">small</field>
+    </record>
+
   </data>
 </odoo>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -38,6 +38,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">10</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_01">
@@ -48,6 +50,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">20</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_02">
@@ -58,6 +62,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">30</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_03">
@@ -68,6 +74,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">40</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_44">
@@ -78,6 +86,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">50</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_45">
@@ -88,6 +98,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">60</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_46">
@@ -98,6 +110,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">70</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_47">
@@ -108,6 +122,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">80</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_48">
@@ -118,6 +134,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">90</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_49">
@@ -128,6 +146,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">100</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_cadre_3">
@@ -148,6 +168,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">110</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_82">
@@ -158,6 +180,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">120</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_83">
@@ -168,6 +192,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">130</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_84">
@@ -178,6 +204,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">140</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_85">
@@ -188,6 +216,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">150</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_86">
@@ -198,6 +228,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">160</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_87">
@@ -208,6 +240,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">170</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_88">
@@ -218,6 +252,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">180</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_cadre_4">
@@ -238,6 +274,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">190</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_55">
@@ -248,6 +286,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">210</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_56">
@@ -258,6 +298,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">220</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_57">
@@ -268,6 +310,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">230</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_61">
@@ -278,6 +322,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">240</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_63">
@@ -288,6 +334,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">250</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_xx">
@@ -318,6 +366,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">270</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_62">
@@ -328,6 +378,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">280</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_64">
@@ -338,6 +390,8 @@
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
+      <field name="auto_expand_accounts" eval="True"/>
+      <field name="auto_expand_accounts_style_id" ref="mis_report_style_l10n_be_acc_det"/>
       <field name="sequence">290</field>
     </record>
     <record model="mis.report.kpi" id="mis_report_vat_grid_yy">


### PR DESCRIPTION
We expand account detail by default in the template. It can be disabled
in the report instance, with recent mis builder versions.