### PR TITLE
[13.0] [FIX] l10n_be_partner_identification: duplicated id codes

### DIFF
--- a/l10n_be_partner_identification/data/l10n_be_partner_identification.xml
+++ b/l10n_be_partner_identification/data/l10n_be_partner_identification.xml
@@ -5,7 +5,7 @@
         id="l10n_be_national_registry_number_category"
     >
         <field name="name">Belgium national registration number</field>
-        <field name="code">L10n_be_id_number</field>
+        <field name="code">be_nat_reg_num</field>
         <field
             name="validation_code"
         ><![CDATA[
@@ -14,7 +14,7 @@ failed = self.validate_l10n_be_national_registry_number(id_number)
     </record>
     <record model="res.partner.id_category" id="l10n_be_id_card_category">
         <field name="name">Belgium ID Card</field>
-        <field name="code">L10n_be_id_number_card</field>
+        <field name="code">be_id_card</field>
         <field
             name="validation_code"
         ><![CDATA[


### PR DESCRIPTION
The code of partner identification category is [limited to 16 characters](https://github.com/OCA/partner-contact/blob/13.0/partner_identification/models/res_partner_id_category.py#L23). Resulting in duplicated codes for the two categories created by this module (they both begin with "L10n_be_id_numbe"), which made the methods `_compute_identification` and `_inverse_identification` crash.

In this PR, I fixed the two categories with shorter codes. It may break existing installations!