### PR TITLE
[FIX] l10n_be_vat_reports: round amounts and format to 2 decimals

### DIFF
--- a/l10n_be_vat_reports/reports/be_vat_client_listing_consignment.xml
+++ b/l10n_be_vat_reports/reports/be_vat_client_listing_consignment.xml
@@ -9,8 +9,8 @@
                 <ns2:ClientListing SequenceNumber="1"
                                    t-att-ClientsNbr="len(partner_vat_list.partner_ids)"
                                    t-att-DeclarantReference="partner_vat_list.declarant_reference"
-                                   t-att-TurnOverSum="partner_vat_list.total_turnover"
-                                   t-att-VATAmountSum="partner_vat_list.total_vat">
+                                   t-att-TurnOverSum="'{:.2f}'.format(partner_vat_list.total_turnover)"
+                                   t-att-VATAmountSum="'{:.2f}'.format(partner_vat_list.total_vat)">
                     <ns2:Declarant>
                         <VATNumber t-esc="res_company.vat[2:]"/>
                         <Name t-esc="res_company.name"/>
@@ -25,8 +25,8 @@
                     <t t-foreach="partner_vat_list.partner_ids" t-as="vat_listing_client">
                         <ns2:Client t-att-SequenceNumber="vat_listing_client.seq">
                             <ns2:CompanyVATNumber issuedBy="BE" t-esc="vat_listing_client.vat[2:]"/>
-                            <ns2:TurnOver t-esc="vat_listing_client.turnover"/>
-                            <ns2:VATAmount t-esc="vat_listing_client.vat_amount"/>
+                            <ns2:TurnOver t-esc="'{:.2f}'.format(vat_listing_client.turnover)"/>
+                            <ns2:VATAmount t-esc="'{:.2f}'.format(vat_listing_client.vat_amount)"/>
                         </ns2:Client>
                     </t>
                     <ns2:Comment t-esc="partner_vat_list.comments"/>

--- a/l10n_be_vat_reports/wizard/partner_vat_list.py
+++ b/l10n_be_vat_reports/wizard/partner_vat_list.py
@@ -54,12 +54,12 @@ class PartnerVATList(models.TransientModel):
     @api.depends("partner_ids")
     def _compute_totals(self):
         for vat_list in self:
-            vat_list.total_turnover = sum(
+            vat_list.total_turnover = round(sum(
                 p.turnover for p in vat_list.partner_ids
-            )
-            vat_list.total_vat = sum(
+            ), 2)
+            vat_list.total_vat = round(sum(
                 p.vat_amount for p in vat_list.partner_ids
-            )
+            ), 2)
 
     @api.multi
     def get_partners(self):
@@ -96,8 +96,8 @@ class PartnerVATList(models.TransientModel):
                                 'tax_tag_64'))
     SELECT sub1.NAME,
            sub1.vat,
-           COALESCE(sub1.turnover, 0) AS turnover,
-           COALESCE(sub2.vat_amount, 0) AS vat_amount
+           ROUND(COALESCE(sub1.turnover, 0), 2) AS turnover,
+           ROUND(COALESCE(sub2.vat_amount, 0), 2) AS vat_amount
     FROM
       (SELECT l.partner_id,
               p.NAME,


### PR DESCRIPTION
Belgian administration only accepts 2 and only 2 decimals in the reports.
Amounts are already rounded in the query to make sure total sums match.