### PR TITLE
[14.0][FIX] Remove the name from the bank.statement.line creation

### DIFF
--- a/account_statement_import_coda/tests/test_import_statement.py
+++ b/account_statement_import_coda/tests/test_import_statement.py
@@ -66,24 +66,6 @@ class TestCodaFile(TransactionCase):
             ),
             0,
         )
-        # check line name
-        self.assertEqual(
-            "MEDEDELING",
-            bank_st_record.line_ids[0].name,
-            "Name should be the communication if no structured communication " "found",
-        )
-        self.assertEqual(
-            "+++240/2838/42818+++",
-            bank_st_record.line_ids[1].name,
-            "Name should be the structured communication id provided",
-        )
-        for line in bank_st_record.line_ids[2:5]:
-            self.assertEqual(
-                "KBC-INVESTERINGSKREDIET 737-6543210-21",
-                line.name,
-                "Name should be the communication of the related "
-                "globalisation line for details line",
-            )
 
         # check the note
         self.assertEqual(

--- a/account_statement_import_coda/wizard/account_statement_import_coda.py
+++ b/account_statement_import_coda/wizard/account_statement_import_coda.py
@@ -161,18 +161,6 @@ class AccountStatementImport(models.TransientModel):
             note.append(_("Communication") + ": " + " ".join(communications))
         return note and "\n".join(note) or None
 
-    def get_st_line_name(self, line, globalisation_dict):
-        """
-        This method must return a valid name for the statement line
-        The name is the statement communication if exists or
-        the communication of the related globalisation line if exists or
-        '/'
-        """
-        name = line.communication
-        if not name and line.ref_move in globalisation_dict:
-            name = globalisation_dict[line.ref_move].communication
-        return name or "/"
-
     def get_st_line_vals(self, line, globalisation_dict, information_dict):
         """
         This method must return a dict of vals that can be passed to create
@@ -185,7 +173,6 @@ class AccountStatementImport(models.TransientModel):
             statement line,
                      it MUST contain at least:
                 {
-                    'name':value,
                     'date':value,
                     'amount':value,
                     'payment_ref':value,
@@ -195,7 +182,6 @@ class AccountStatementImport(models.TransientModel):
         if line.transaction_amount_sign == AmountSign.DEBIT:
             amount = -amount
         return {
-            "name": self.get_st_line_name(line, globalisation_dict),
             "date": line.entry_date or datetime.datetime.now().date(),
             "amount": amount,
             "payment_ref": line.communication or line.ref,


### PR DESCRIPTION
The field doesn't exist anymore on this model, but is inherit from the account.move.line.
The name of the account.move.line is auto generated when posted if empty.
Setting it to the communication of the coda can lead to a validation exception from the sequence.mixin
 since it can extract a year from it (such as a structured communication, see _constrains_date_sequence)
