### PR TITLE
[14.0][FIX] account_statement_import_coda: note should only contain info of the current move

### DIFF
--- a/account_statement_import_coda/wizard/account_statement_import_coda.py
+++ b/account_statement_import_coda/wizard/account_statement_import_coda.py
@@ -116,10 +116,10 @@ class AccountStatementImport(models.TransientModel):
             if st.type == MovementRecordType.GLOBALISATION
         }
         information_dict = {}
-        # build a dict of information by transaction_ref. The transaction_ref
-        # refers to the transaction_ref of a movement record
+        # build a dict of information by ref_move. The ref_move
+        # refers to the ref_move of a movement record
         for info_line in statement.informations:
-            infos = information_dict.setdefault(info_line.transaction_ref, [])
+            infos = information_dict.setdefault(info_line.ref_move, [])
             infos.append(info_line)
 
         for sequence, line in enumerate(
@@ -151,7 +151,7 @@ class AccountStatementImport(models.TransientModel):
             note.append(_("Counter Party Account") + ": " + line.counterparty_number)
         if line.counterparty_address:
             note.append(_("Counter Party Address") + ": " + line.counterparty_address)
-        infos = information_dict.get(line.transaction_ref, [])
+        infos = information_dict.get(line.ref_move, [])
         if line.communication or infos:
             communications = []
             if line.communication:


### PR DESCRIPTION
Information about all transaction lines (name, bank account, address) were repeated in note field od each transaction line 
![wrong_transaction](https://user-images.githubusercontent.com/89970854/213469852-98f6e7e0-2d23-41d2-bf4e-5ca2accf6077.png)

With this modification we want in a transaction line to stock only the information of the current line. 

![good_transaction](https://user-images.githubusercontent.com/89970854/213469877-0fa7acd5-16df-4708-bd0c-e993379e089b.png)
