### PR TITLE
[FIX] l10n_be_cooperator: tax shelter cron

### DIFF
--- a/l10n_be_cooperator/__manifest__.py
+++ b/l10n_be_cooperator/__manifest__.py
@@ -8,7 +8,7 @@
 {
     "name": "Cooperators Belgium",
     "summary": "Cooperators Belgium Localization",
-    "version": "14.0.1.2.1",
+    "version": "14.0.1.2.2",
     "depends": [
         "cooperator",
         "cooperator_website",

--- a/l10n_be_cooperator/data/scheduler_data.xml
+++ b/l10n_be_cooperator/data/scheduler_data.xml
@@ -3,7 +3,10 @@
     <data noupdate="1">
         <record forcecreate="True" id="ir_cron_mail_tax_shelter_action" model="ir.cron">
             <field name="name">Tax shelter mail batch mail</field>
-            <field name="model_id" ref="model_tax_shelter_certificate" />
+            <field
+                name="model_id"
+                ref="l10n_be_cooperator.model_tax_shelter_certificate"
+            />
             <field name="state">code</field>
             <field name="code">model.batch_send_tax_shelter_certificate()
             </field>

--- a/l10n_be_cooperator/migrations/14.0.1.2.2/pre-migrate.py
+++ b/l10n_be_cooperator/migrations/14.0.1.2.2/pre-migrate.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Coop IT Easy SC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Delete ir_cron_mail_tax_shelter_action.")
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    cron = env.ref("l10n_be_cooperator.ir_cron_mail_tax_shelter_action")
+    data = env["ir.model.data"].search(
+        [
+            ("name", "=", "ir_cron_mail_tax_shelter_action"),
+            ("module", "=", "l10n_be_cooperator"),
+        ]
+    )
+
+    cron.unlink()
+    data.unlink()


### PR DESCRIPTION
The module name was missing in the model_id field. Odoo thus
failed to find the model upon cron execution.

Since the data is set as nocreate=True, we need a pre-migration
script to force data recreation.
