### PR TITLE
[FIX] l10n_be_cooperator: Remove space characters from e-mail fields in template

### DIFF
--- a/l10n_be_cooperator/data/mail_template_data.xml
+++ b/l10n_be_cooperator/data/mail_template_data.xml
@@ -5,14 +5,14 @@
     <data noupdate="1">
         <record id="email_template_tax_shelter_certificate" model="mail.template">
             <field name="name">Tax Shelter Certificate - Send By Email</field>
-            <field name="email_from">
-                ${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}
-            </field>
+            <field
+                name="email_from"
+            >${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}</field>
             <field name="subject">Tax Shelter Certificate</field>
             <field name="partner_to">${object.partner_id.id}</field>
-            <field name="reply_to">
-                ${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}
-            </field>
+            <field
+                name="reply_to"
+            >${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}</field>
             <field name="model_id" ref="model_tax_shelter_certificate" />
             <field name="auto_delete" eval="True" />
             <field name="lang">${object.partner_id.lang}</field>


### PR DESCRIPTION
This was causing e-mails to fail to send.

Internal task: https://gestion.coopiteasy.be/web#id=10399&model=project.task&view_type=form&menu_id=