### PR TITLE
[12.0][FIX] control vat format on vat client listing

### DIFF
--- a/l10n_be_vat_reports/wizard/partner_vat_list.py
+++ b/l10n_be_vat_reports/wizard/partner_vat_list.py
@@ -41,7 +41,8 @@ class PartnerVATList(models.TransientModel):
                 _("No VAT number associated with your company.")
             )
 
-        company_vat = company_vat.replace(" ", "").upper()
+        be_id = self.env.ref("base.be").id
+        company_vat = self.env["res.partner"].fix_eu_vat_number(be_id, company_vat)
         for listing in self:
             seq_declarantnum = self.env["ir.sequence"].next_by_code(
                 "declarantnum"
@@ -67,6 +68,7 @@ class PartnerVATList(models.TransientModel):
         date_start = date(int(self.year), 1, 1)
         date_stop = date(int(self.year), 12, 31)
 
+        be_id = self.env.ref("base.be").id
         partners = self.env["partner.vat.list.client"].browse([])
         be_partners = self.env["res.partner"].search([("vat", "ilike", "BE%")])
         if not be_partners:
@@ -140,7 +142,9 @@ class PartnerVATList(models.TransientModel):
         self.env.cr.execute(query, args)
         seq = 0
         for record in self.env.cr.dictfetchall():
-            record["vat"] = record["vat"].replace(" ", "").upper()
+            record["vat"] = self.env["res.partner"].fix_eu_vat_number(
+                be_id, record["vat"]
+                )
             if record["turnover"] >= self.limit_amount:
                 seq += 1
                 record["seq"] = seq

--- a/l10n_be_vat_reports/wizard/partner_vat_list_client.py
+++ b/l10n_be_vat_reports/wizard/partner_vat_list_client.py
@@ -21,17 +21,17 @@ class VATListingClients(models.TransientModel):
     @api.constrains("vat")
     def _check_vat_number(self):
         """
-        Belgium VAT numbers must respect this pattern: 0[1-9]{1}[0-9]{8}
+        Belgium VAT numbers must respect this pattern: [0-1][0-9]{9}
         todo current code assumes vat numbers start with a two-letter
           country code
         """
-        be_vat_pattern = re.compile(r"^BE0[1-9]{1}[0-9]{8}$")
+        be_vat_pattern = re.compile(r"^BE[0-1][0-9]{9}$")
         for client in self:
             if not be_vat_pattern.match(client.vat):
                 raise ValidationError(
                     _(
                         "Belgian Intervat platform only accepts VAT numbers "
-                        "matching this pattern: 0[1-9]{1}[0-9]{8} (number "
+                        "matching this pattern: [0-1][0-9]{9} (number "
                         "part). Check vat number %s for client %s"
                     )
                     % (client.vat, client.name)


### PR DESCRIPTION
Belgian VAT number now can start with a 1 rather than a 0 (see https://www.easytax.co/fr/tax-mag/info/belgique-changement-de-format-pour-les-numeros-de-tva-belges/)

Also autoremove the dots in the VAT numbers (they are not checked by the VIES control, but produce errors in the VAT client listing report)

forward ported in v14 : https://github.com/OCA/l10n-belgium/pull/217