### PR TITLE
[14.0][FIX] control vat format on vat client listing 

### DIFF
--- a/l10n_be_vat_reports/wizard/partner_vat_list.py
+++ b/l10n_be_vat_reports/wizard/partner_vat_list.py
@@ -47,6 +47,7 @@ class PartnerVATList(models.TransientModel):
         partners = partner_vat_list_client_model.browse([])
         turnover_tags = ("00", "01", "02", "03", "45", "49")
         vat_tags = ("54", "64")
+        be_id = self.env.ref("base.be").id
 
         # query explanation:
         #
@@ -156,7 +157,9 @@ where
         }
         self.env.cr.execute(query, args)
         for seq, record in enumerate(self.env.cr.dictfetchall(), start=1):
-            record["vat"] = record["vat"].replace(" ", "").upper()
+            record["vat"] = self.env["res.partner"].fix_eu_vat_number(
+                be_id, record["vat"]
+            )
             record["seq"] = seq
             partners |= partner_vat_list_client_model.create(record)
 

--- a/l10n_be_vat_reports/wizard/partner_vat_list_client.py
+++ b/l10n_be_vat_reports/wizard/partner_vat_list_client.py
@@ -20,17 +20,17 @@ class VATListingClients(models.TransientModel):
     @api.constrains("vat")
     def _check_vat_number(self):
         """
-        Belgium VAT numbers must respect this pattern: 0[1-9]{1}[0-9]{8}
+        Belgium VAT numbers must respect this pattern: [0-1][0-9]{9}
         todo current code assumes vat numbers start with a two-letter
           country code
         """
-        be_vat_pattern = re.compile(r"^BE0[1-9]{1}[0-9]{8}$")
+        be_vat_pattern = re.compile(r"^BE[0-1][0-9]{9}$")
         for client in self:
             if not be_vat_pattern.match(client.vat):
                 raise ValidationError(
                     _(
                         "Belgian Intervat platform only accepts VAT numbers "
-                        "matching this pattern: 0[1-9]{1}[0-9]{8} (number "
+                        "matching this pattern: [0-1][0-9]{9} (number "
                         "part). Check vat number %s for client %s"
                     )
                     % (client.vat, client.name)


### PR DESCRIPTION
forward port of : https://github.com/OCA/l10n-belgium/pull/216

- Belgian VAT number now can start with a 1 rather than a 0 (see https://www.easytax.co/fr/tax-mag/info/belgique-changement-de-format-pour-les-numeros-de-tva-belges/). 
- use odoo's vat autocorrect for the VAT numbers (currently dots are they are not checked by the VIES control, but produce errors in the VAT client listing report)
