### PR TITLE
[FIX] l10n_be_bpost_address_autocomplete: remove headers from api call

### DIFF
--- a/l10n_be_bpost_address_autocomplete/static/lib/bp-address-auto-complete/bp-address-autocomplete-search-bar.js
+++ b/l10n_be_bpost_address_autocomplete/static/lib/bp-address-auto-complete/bp-address-autocomplete-search-bar.js
@@ -224,11 +224,9 @@ let BpAddressAutocomplete = class BpAddressAutocomplete extends s$1 {
     }
     async _sendRequest(input) {
         this.count++;
-        await fetch(`https://webservices-pub.bpost.be/ws/ExternalMailingAddressProofingCSREST_v1/address/autocomplete?id=${this.count}&q=${input.value}`, {
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-            },
-        }).then(response => {
+        await fetch(
+            `https://webservices-pub.bpost.be/ws/ExternalMailingAddressProofingCSREST_v1/address/autocomplete?id=${this.count}&q=${input.value}`
+        ).then(response => {
             if (!response.ok) {
                 this.suggestions = [];
                 throw new Error("Network response was not OK");

--- a/l10n_be_bpost_address_autocomplete/tests/test_res_partner.py
+++ b/l10n_be_bpost_address_autocomplete/tests/test_res_partner.py
@@ -1,4 +1,7 @@
+import requests
+
 from odoo.tests.common import TransactionCase
+from odoo.tools.misc import mute_logger
 
 
 class TestResPartner(TransactionCase):
@@ -25,3 +28,14 @@ class TestResPartner(TransactionCase):
         self.partner_be.is_belgian_address = False
         self.partner_be._onchange_is_belgian_address()
         self.assertFalse(self.partner_be.country_id == self.env.ref("base.be"))
+
+    @mute_logger("py.warnings")
+    def test_api_call(self):
+        response = requests.get(
+            "https://webservices-pub.bpost.be/ws/"
+            "ExternalMailingAddressProofingCSREST_v1/address/autocomplete?"
+            "id=1&q=watterloo",
+            timeout=10,
+            verify=False,
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Since the required headers are no more supported, this commit removes them from the api call in order to successfully fetch the results.