### PR TITLE
[FIX] add test dependencies to manifest

### DIFF
--- a/companyweb_base/__manifest__.py
+++ b/companyweb_base/__manifest__.py
@@ -24,6 +24,8 @@
     "external_dependencies": {
         "python": [
             "zeep",
+            "freezegun",
+            "vcrpy-unittest",
         ],
     },
     # Wait for meb-notify to be migrated in 15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # generated from manifests external_dependencies
+freezegun
 pycoda
+vcrpy-unittest
 zeep


### PR DESCRIPTION
It makes more sense to add the dependencies in the manifest <br/>
This module is installable via odoo app store and for now it does not work <br/>
Odoo run the tests when installing the module and the test dependencies are not installed <br/>
For a tech profile it is not a big issue but for non tech user it can be <br/>
Generic discussion to have : why not always include test dependencies in the manifest ?

@sbidoul 