### PR TITLE
[16.0][IMP] account_statement_import_coda: Import Multi-Statements file with Different Currencies and Account Numbers

### DIFF
--- a/account_statement_import_coda/wizard/account_statement_import_coda.py
+++ b/account_statement_import_coda/wizard/account_statement_import_coda.py
@@ -54,11 +54,18 @@ class AccountStatementImport(models.TransientModel):
     def _parse_file(self, data_file):
         if not self._check_coda(data_file):
             return super()._parse_file(data_file)
-        vals_bank_statements = []
+
+        parsed_statements = []
         try:
             statements = Parser().parse(data_file)
             for statement in statements:
-                vals_bank_statements.append(self.get_st_vals(statement))
+                parsed_statements.append(
+                    (
+                        statement.currency,
+                        self._get_acc_number(statement.acc_number),
+                        [self.get_st_vals(statement)],
+                    )
+                )
         except Exception as e:
             _logger.exception("Error when parsing coda file")
             raise UserError(
@@ -68,13 +75,7 @@ class AccountStatementImport(models.TransientModel):
                 )
                 % e
             ) from e
-
-        acc_number = None
-        currency = None
-        if statements:
-            acc_number = statements[0].acc_number
-            currency = statement.currency
-        return currency, self._get_acc_number(acc_number), vals_bank_statements
+        return parsed_statements
 
     def get_st_vals(self, statement):
         """


### PR DESCRIPTION
## Description
This update enhances the `_parse_file` method to properly handle CODA files containing multiple bank statements with different currencies and account numbers. Previously, the method only extracted the currency and account number from the first statement, which could lead to incorrect processing when multiple statements with different currencies and account numbers were present.

### **Changes Introduced**
- The method now iterates over all parsed statements instead of assuming a single currency.
- Each statement's currency, account number, and values are stored as a tuple in a list.
- The return value is now a **list of triples**:  `[(currency, self._get_acc_number(acc_number), statement_values)]`
- This ensures that bank statements with different currencies and account numbers are correctly processed.

### **Why is this needed?**
- Some CODA files contain multiple bank statements, each potentially in a different currency and/or account number.
- The previous implementation only captured the first statement’s currency and account number, leading to inconsistencies when processing multi-statements CODA.
