### PR TITLE
[16.0][FIX] fix tests following Odoo change in loading test CoA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
         run: manifestoo -d . check-dev-status --default-dev-status=Beta
       - name: Initialize test db
         run: oca_init_test_database
+      - name: Load l10n_generic_coa
+        run: odoo -d odoo -i l10n_generic_coa --stop-after-init
       - name: Run tests
         run: oca_run_tests
       - uses: codecov/codecov-action@v4

--- a/l10n_be_intrastat_product/tests/test_intrastat_be.py
+++ b/l10n_be_intrastat_product/tests/test_intrastat_be.py
@@ -15,6 +15,7 @@ class TestIntrastatBe(TransactionCase):
 
         cls.company = cls.env.company
         cls.env.company.country_id = cls.env.ref("base.be")
+        cls.env.company.account_fiscal_country_id = cls.env.ref("base.be")
         cls.env.company.vat = "BE0820512013"
         cls.company.intrastat_region_id = cls.env.ref(
             "l10n_be_intrastat_product.intrastat_region_2"
@@ -113,7 +114,6 @@ class TestIntrastatBe(TransactionCase):
         )
 
     def test_be_sale_b2b(self):
-
         inv_out = self.inv_obj.with_context(default_move_type="out_invoice").create(
             {
                 "partner_id": self.partner_b2b_1.id,
@@ -149,7 +149,7 @@ class TestIntrastatBe(TransactionCase):
         # not in the module dependency (we check the presence of
         # this module via hasattr)
         sale_journal_rec = self.env["account.journal"].search(
-            [("type", "=", "sale")], limit=1
+            [("type", "=", "sale"), ("company_id", "=", self.env.company.id)], limit=1
         )
         reversal = (
             self.env["account.move.reversal"]
@@ -184,7 +184,6 @@ class TestIntrastatBe(TransactionCase):
         self.assertEqual(dlines[0].amount_company_currency, 0.0)
 
     def test_be_sale_b2b_na(self):
-
         inv_out = self.inv_obj.with_context(default_move_type="out_invoice").create(
             {
                 "partner_id": self.partner_b2b_na.id,
@@ -236,7 +235,6 @@ class TestIntrastatBe(TransactionCase):
         self.assertEqual(dlines[0].vat, "QV999999999999")
 
     def test_be_purchase(self):
-
         inv_in1 = self.inv_obj.with_context(default_move_type="in_invoice").create(
             {
                 "partner_id": self.partner_b2b_1.id,

--- a/l10n_be_vat_reports/tests/common.py
+++ b/l10n_be_vat_reports/tests/common.py
@@ -3,13 +3,19 @@
 
 from lxml.etree import XML
 
+from odoo.fields import Command
 from odoo.tests.common import TransactionCase
 
 
 class TestVatReportsCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.env.ref("l10n_be.demo_company_be")
+        cls.env.user.company_id = company
+        cls.env.user.company_ids = [Command.set(company.ids)]
+
     def _create_test_data(self, invoice_tax):
-        chart = self.env.ref("l10n_be.l10nbe_chart_template")
-        chart.try_loading()
         company = self.env.company
         company.partner_id.write({"vat": "PT999999990"})
         self.partner = self.env["res.partner"].create(


### PR DESCRIPTION
- l10n_be_vat_reports: make sure to use a company with the l10n_be taxes loaded. Otherwise the `_get_tax` calls in the tests fail because the belgian taxes are not created for the test company.
- fix a couple of bugs in the l10n_be_intrastat_product tests
- pre-load l10n_generic_coa to work around odoo/odoo@d0342c8