### PR TITLE
[18.0][FIX] companyweb_base: Fix access rights on user profile

### DIFF
--- a/companyweb_base/models/res_users.py
+++ b/companyweb_base/models/res_users.py
@@ -2,11 +2,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
-from odoo.addons.base.models import res_users
-
-res_users.USER_PRIVATE_FIELDS.append("cweb_login")
-res_users.USER_PRIVATE_FIELDS.append("cweb_password")
-
 
 class CompanyWebUser(models.Model):
     _inherit = "res.users"
@@ -14,3 +9,7 @@ class CompanyWebUser(models.Model):
     # If empty, the user will be prompted for these fields via a wizard.
     cweb_login = fields.Char("Companyweb Login")
     cweb_password = fields.Char("Companyweb Password")
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ["cweb_login", "cweb_password"]


### PR DESCRIPTION
Access error on user profile:

### Error
- Install fleet (it's not related to fleet but that's where we had the error)
- Install companyweb_base
- Log in as a user (non-admin), click on top-right menu "my profile"
-> Access error on field `employee_cars_count`

### Cause
If not all fields that are being read are in `SELF_READABLE_FIELDS` it will not use sudo to read:
[`base/models/res_users.py:665`](https://github.com/odoo/odoo/blob/0bbadddcf5a60f9005192dd0ce75ae7c4b11dcec/odoo/addons/base/models/res_users.py#L665)

### Fix
Add fields to `SELF_READABLE_FIELDS` instead of `USER_PRIVATE_FIELDS`