### PR TITLE
[16.0][FIX] l10n_be_mis_reports_xml: fix vat declaration data extraction

### DIFF
--- a/l10n_be_mis_reports_xml/wizards/be_vat_declaration_wizard.py
+++ b/l10n_be_mis_reports_xml/wizards/be_vat_declaration_wizard.py
@@ -77,17 +77,18 @@ class BeVATDeclarationWizard(models.TransientModel):
 
     def prepare_xml_data(self):
         self.ensure_one()
-        kpi_matrix_dict = self.mr_instance_id.compute()
-        data = {
-            row["row_id"]: row["cells"][0]["val"] for row in kpi_matrix_dict["body"]
-        }
-
-        data = {
+        report = self.mr_instance_id.report_id
+        data = report.evaluate(
+            report._prepare_aep(self.mr_instance_id.company_id),
+            self.mr_instance_id.date_from,
+            self.mr_instance_id.date_to,
+        )
+        xml_data = {
             k: "{:.2f}".format(round(v, 2))
             for k, v in data.items()
             if k.startswith("grid") and v
         }
-        return data
+        return xml_data
 
     def compute_declarant_reference(self):
         return self.env["ir.sequence"].next_by_code("be.vat.declaration.declarant")


### PR DESCRIPTION
make data extraction for xml export work regardless of changes in row and cell naming in mis_builder 16.0.5.3.0. (see changes [here](https://github.com/OCA/mis-builder/pull/676/files#diff-47080a2f9b9511ea77d42be1af586127872382ce2cd198c69e11f195612fe5c0R47).)

note: tests are failing because `l10n_be_intrastat_product` did not yet adapt to changes from OCA/intrastat-extrastat#306 (fixed in #261).