### PR TITLE
[16.0][FIX] l10n_be_intrastat_product: fix hs.code query: remove company_id

### DIFF
--- a/l10n_be_intrastat_product/models/intrastat_product_declaration.py
+++ b/l10n_be_intrastat_product/models/intrastat_product_declaration.py
@@ -182,13 +182,7 @@ class IntrastatProductDeclaration(models.Model):
             # Current version implements only regular credit notes
             special_code = "99600000"
             hs_code = self.env["hs.code"].search(
-                [
-                    ("local_code", "=", special_code),
-                    "|",
-                    ("company_id", "=", self.company_id.id),
-                    ("company_id", "=", False),
-                ],
-                limit=1,
+                [("local_code", "=", special_code)], limit=1
             )
             if not hs_code:
                 msg = (


### PR DESCRIPTION
remove `company_id` in `hs.code` query, as this field has been removed in `product_harmonized_system` 16.0.2.0.0.