### PR TITLE
[FIX] Guard against balance_data_dict_parent being None

### DIFF
--- a/companyweb_base/cweb_utils.py
+++ b/companyweb_base/cweb_utils.py
@@ -110,25 +110,26 @@ def get_balance_values(data):
         }
     )
     if balance_enable and balance_data:
-        balance_details = {
-            d[NESTED_KEYS["balance_data_key"]]: d[NESTED_KEYS["balance_data_value"]]
-            for d in balance_data[NESTED_KEYS["balance_data_dict_parent"]][
-                NESTED_KEYS["balance_data_dict_child"]
-            ]
-        }
-
         values.update(
             {
                 balance_field: balance_data[NESTED_KEYS[balance_field]]
                 for balance_field in BALANCE_FIELDS
             }
         )
-        values.update(
-            {
-                balance_field: balance_details[NESTED_KEYS[balance_field]]
-                for balance_field in BALANCE_NESTED_FIELDS
+
+        if balance_data[NESTED_KEYS["balance_data_dict_parent"]]:
+            balance_details = {
+                d[NESTED_KEYS["balance_data_key"]]: d[NESTED_KEYS["balance_data_value"]]
+                for d in balance_data[NESTED_KEYS["balance_data_dict_parent"]][
+                    NESTED_KEYS["balance_data_dict_child"]
+                ]
             }
-        )
+            values.update(
+                {
+                    balance_field: balance_details[NESTED_KEYS[balance_field]]
+                    for balance_field in BALANCE_NESTED_FIELDS
+                }
+            )
     else:
         # Set balance fields to False if not available
         values.update(


### PR DESCRIPTION
The diff makes the change seem more involved than it is, this fix just moves and indents two small blocks to add this check before them:
```py
if balance_data[NESTED_KEYS["balance_data_dict_parent"]]:
```
As the two blocks assume that this balance_data value can't be `None`, which it actually can be as we have observed with one of our customers, resulting in an ugly `TypeError: 'NoneType' object is not subscriptable` exception.